### PR TITLE
Change isNegative to be correct

### DIFF
--- a/bigint_func.circom
+++ b/bigint_func.circom
@@ -2,7 +2,7 @@ pragma circom 2.0.2;
 
 function isNegative(x) {
     // half babyjubjub field size
-    return x > 10944121435919637611123202872628637544274182200208017171849102093287904247808 ? 1 : 0;
+    return x < 0 ? 1 : 0;
 }
 
 function div_ceil(m, n) {


### PR DESCRIPTION
Per circom documentation, the < operator first puts the inputs in the range [-p/2, p/2] before comparing, so isNegative should just check x < 0. The previous version will always return 0.